### PR TITLE
Fix filter_unused for empty Rtree

### DIFF
--- a/libs/processing/rtree.py
+++ b/libs/processing/rtree.py
@@ -59,9 +59,11 @@ class RectangleTree:
                         self.index.delete(candidate.id, candidate.bbox)
     
     def filter_unused(self):
-        all_rectangles = list(self.index.intersection(self.index.get_bounds(), objects=True))
-        unused_rectangles = []
-        for item in all_rectangles:
-            if item.id not in self.used_rois:
-                unused_rectangles.append(Rectangle(*item.bbox, item.object))
-        return unused_rectangles
+        if self.index.get_size() != 0:
+            all_rectangles = list(self.index.intersection(self.index.get_bounds(), objects=True))
+            unused_rectangles = []
+            for item in all_rectangles:
+                if item.id not in self.used_rois:
+                    unused_rectangles.append(Rectangle(*item.bbox, item.object))
+            return unused_rectangles
+        return []


### PR DESCRIPTION
If one of the services does not return OCR results and the Rtree is empty, the `filter_unused` was not working properly. Now it returns an empty list.

Close #51.