### PR TITLE
Limit image size before OCR processing

### DIFF
--- a/dry_processing.py
+++ b/dry_processing.py
@@ -7,9 +7,9 @@ from libs.processing.align_images import align_images
 from libs.processing.read_content import process_content
 from libs.processing.store_results import store_results
 from libs.visualise_regions import annotate_pdfs
-
 from libs.region import Rectangle
 from tests.extracted_content import EXTRACTED
+from libs.pdf_to_image import get_image_size
 
 
 def load_stored_results(test_set):
@@ -31,12 +31,12 @@ def load_stored_results(test_set):
            }
 
 
-def preprocess_input(scanned_logsheet, template, config, page):
+def preprocess_input(scanned_logsheet, template, config, page, max_size=4, dpi=300):
     # convert pdfs to images
-    template_image = convert_pdf_to_image(template)
+    template_image = convert_pdf_to_image(template, dpi=dpi)
     template_image = np.array(template_image)
 
-    logsheet_image = convert_pdf_to_image(scanned_logsheet, page)
+    logsheet_image = convert_pdf_to_image(scanned_logsheet, page, dpi=dpi)
     logsheet_image = np.array(logsheet_image)
 
     # resize images
@@ -45,6 +45,9 @@ def preprocess_input(scanned_logsheet, template, config, page):
 
     # fix logsheet_image (reorient and scale)
     logsheet_image = align_images(logsheet_image, template_image)
+
+    if get_image_size(logsheet_image) > max_size * 2**20:
+        logsheet_image = preprocess_input(scanned_logsheet, template, config, page, max_size, dpi=dpi-50)
     return logsheet_image
 
 

--- a/libs/pdf_to_image.py
+++ b/libs/pdf_to_image.py
@@ -1,19 +1,22 @@
 from pdf2image import convert_from_path
 import cv2
+from io import BytesIO
+from PIL import Image
 
 
-def convert_pdf_to_image(pdf_path, page=0):
+def convert_pdf_to_image(pdf_path, page=0, dpi=300):
     """
     Convert PDF to image (assume only one page).
 
     Args:
         pdf_path (str): path to given PDF file
         page (int): page number to be extracted. Defaults to 0.
+        dpi (int): quality of picture in DPI. Defaults to 300.
 
     Returns:
         Image: converted image
     """
-    return convert_from_path(pdf_path, dpi=300)[page]
+    return convert_from_path(pdf_path, dpi=dpi)[page]
 
 
 def resize_image(image, size):
@@ -28,3 +31,18 @@ def resize_image(image, size):
         Image: scaled image
     """
     return cv2.resize(image, size, interpolation = cv2.INTER_AREA)
+
+
+def get_image_size(logsheet_image):
+    """Find the size of the image
+
+    Args:
+        logsheet_image (np.array): image of interest
+
+    Returns:
+        int: size in bytes
+    """
+    img_file = BytesIO()
+    image = Image.fromarray(logsheet_image)
+    image.save(img_file, 'png', quality='keep')
+    return img_file.tell()

--- a/process_logsheet.py
+++ b/process_logsheet.py
@@ -9,6 +9,7 @@ from libs.processing.read_content import process_content
 from libs.processing.store_results import store_results
 from libs.services.call_services import call_services
 from libs.visualise_regions import annotate_pdfs
+from libs.pdf_to_image import get_image_size
 
 
 def load_credentials(google_credentials, amazon_credentials, azure_credentials):
@@ -20,12 +21,13 @@ def load_credentials(google_credentials, amazon_credentials, azure_credentials):
 
     return {'google': google_credentials, 'amazon': amazon_credentials, 'azure': azure_credentials}
 
-def preprocess_input(scanned_logsheet, template, config, page):
+
+def preprocess_input(scanned_logsheet, template, config, page, max_size=4, dpi=300):
     # convert pdfs to images
-    template_image = convert_pdf_to_image(template)
+    template_image = convert_pdf_to_image(template, dpi=dpi)
     template_image = np.array(template_image)
 
-    logsheet_image = convert_pdf_to_image(scanned_logsheet, page)
+    logsheet_image = convert_pdf_to_image(scanned_logsheet, page, dpi=dpi)
     logsheet_image = np.array(logsheet_image)
 
     # resize images
@@ -34,6 +36,9 @@ def preprocess_input(scanned_logsheet, template, config, page):
 
     # fix logsheet_image (reorient and scale)
     logsheet_image = align_images(logsheet_image, template_image)
+
+    if get_image_size(logsheet_image) > max_size * 2**20:
+        logsheet_image = preprocess_input(scanned_logsheet, template, config, page, max_size, dpi=dpi-50)
     return logsheet_image
 
 


### PR DESCRIPTION
Make sure the image has under 4MB before processing.
This is mainly because the is hard limit in Azure service.

Close #50.