### PR TITLE
Messy Azure coordinates

### DIFF
--- a/libs/processing/process_area.py
+++ b/libs/processing/process_area.py
@@ -140,6 +140,18 @@ def majority_vote(strings):
     return ''.join(result)
 
 
+def remove_non_ascii(string):
+    """Remove non-ascii characters (these do not work in the alignment)
+
+    Args:
+        string (str): input line
+
+    Returns:
+        str: line containing only ascii characters
+    """
+    return ''.join(char for char in string if ord(char) < 128)
+
+
 def identify_words(lines, is_number):
     """Identify words from lines.
     Behaves differently based on how many lines there are.
@@ -151,7 +163,10 @@ def identify_words(lines, is_number):
     Returns:
         str: identified word
     """
+    # curate lines
     lines = list(filter(None, lines))
+    lines = list(map(remove_non_ascii, lines))
+
     if len(lines) == 1:
         return lines[0]
     elif len(lines) == 2:

--- a/libs/services/azure_vision.py
+++ b/libs/services/azure_vision.py
@@ -5,6 +5,7 @@ from azure.cognitiveservices.vision.computervision.models._models_py3 import Com
 import time
 
 from libs.region import Rectangle
+from libs.services.utils import extract_corners
 
 
 class AzureVision:
@@ -41,5 +42,6 @@ class AzureVision:
             for line in outputs.analyze_result.read_results[0].lines:
                 for word in line.words:
                     vertices = word.bounding_box
-                    identified.append(Rectangle(*vertices[0:2], *vertices[4:6], word.text))
+                    start, end = extract_corners([vertices[0:2], vertices[4:6]])
+                    identified.append(Rectangle(*start, *end, word.text))
         return identified

--- a/libs/services/google_vision.py
+++ b/libs/services/google_vision.py
@@ -2,23 +2,7 @@ from google.cloud import vision_v1
 from google.oauth2 import service_account
 
 from libs.region import Rectangle
-
-
-def extract_corners(points):
-    """Identify bounding box for given polygon
-
-    Args:
-        points (list): list of coordinates
-
-    Returns:
-        list: top-left and bottom-right coordinates
-    """
-    min_x = min(points, key=lambda pt: pt[0])[0]
-    min_y = min(points, key=lambda pt: pt[1])[1]
-    max_x = max(points, key=lambda pt: pt[0])[0]
-    max_y = max(points, key=lambda pt: pt[1])[1]
-    
-    return (min_x, min_y), (max_x, max_y)
+from libs.services.utils import extract_corners
 
 
 class GoogleVision:

--- a/libs/services/utils.py
+++ b/libs/services/utils.py
@@ -1,0 +1,15 @@
+def extract_corners(points):
+    """Identify bounding box for given polygon
+
+    Args:
+        points (list): list of coordinates
+
+    Returns:
+        list: top-left and bottom-right coordinates
+    """
+    min_x = min(points, key=lambda pt: pt[0])[0]
+    min_y = min(points, key=lambda pt: pt[1])[1]
+    max_x = max(points, key=lambda pt: pt[0])[0]
+    max_y = max(points, key=lambda pt: pt[1])[1]
+    
+    return (min_x, min_y), (max_x, max_y)

--- a/libs/statistics.py
+++ b/libs/statistics.py
@@ -10,6 +10,7 @@ def compute_success_ratio(contents, artefacts):
     """
     num_of_identified = len(contents)
     max_artefacts = max([len(items) for items in artefacts.values()])
+    ratio = num_of_identified/max(max_artefacts, 1) # to avoid division by zero
     return {'identified': num_of_identified, 
             'artefacts': max_artefacts, 
-            'ratio': num_of_identified/max_artefacts}
+            'ratio': ratio}


### PR DESCRIPTION
This PR fixes the cases when coordinates in outputs from Azure are messed up, i.e. they are swapped.
I have also fixed minor bug in statistics (possible division by zero :O) and removed all non-ascii charactes from texts (these do not work well in alignment step, causes seg. fault in the `Biopython.pairwise2` function).

Close #56.