### PR TITLE
Highlight bool cells in the output file

### DIFF
--- a/libs/processing/checkbox.py
+++ b/libs/processing/checkbox.py
@@ -36,4 +36,4 @@ def is_ticked(image_array, edge_ignore_percentage=0.2, threshold_percentage=0.1)
     black_percentage = black_pixels / total_pixels
 
     # Determine if checked
-    return black_percentage > threshold_percentage
+    return bool(black_percentage > threshold_percentage)

--- a/libs/processing/store_results.py
+++ b/libs/processing/store_results.py
@@ -75,6 +75,7 @@ def store_results(results, artefacts, output_file):
         worksheet.write(f'B{row_number}', inferred)
 
         if type(inferred) == bool:
+            worksheet.data_validation(f'B{row_number}', {'validate': 'list', 'show_error': False, 'source': [True, False]})
             worksheet.conditional_format(f'B{row_number}', {'type': 'cell',
                                          'criteria': '==',
                                          'value': True,

--- a/libs/processing/store_results.py
+++ b/libs/processing/store_results.py
@@ -59,6 +59,8 @@ def store_results(results, artefacts, output_file):
 
     max_width = 0
 
+    bool_format = workbook.add_format({'bg_color': '#f1e740'})
+
     # fill in data
     for row_number, result in enumerate(results, 2):
         worksheet.write(f'A{row_number}', result[0])
@@ -71,6 +73,12 @@ def store_results(results, artefacts, output_file):
             inferred = values[0]
 
         worksheet.write(f'B{row_number}', inferred)
+
+        if type(inferred) == bool:
+            worksheet.conditional_format(f'B{row_number}', {'type': 'cell',
+                                         'criteria': '==',
+                                         'value': True,
+                                         'format': bool_format})
 
         filename = store_image(result[2], images_directory, row_number)
         height, width, _ = result[2].shape


### PR DESCRIPTION
Add list of values (True/False) for bool type of cells in the output Excel sheet. 
The cells with `True` value are highlighted to speed up manual validation.

Close #59.