### PR TITLE
[Bug fix] remove non-ascii corner case

### DIFF
--- a/libs/processing/process_area.py
+++ b/libs/processing/process_area.py
@@ -164,8 +164,8 @@ def identify_words(lines, is_number):
         str: identified word
     """
     # curate lines
-    lines = list(filter(None, lines))
     lines = list(map(remove_non_ascii, lines))
+    lines = list(filter(None, lines))
 
     if len(lines) == 1:
         return lines[0]


### PR DESCRIPTION
Cover a corner case of removing special characters - remove empty lines after non-ascii characters were removed, not before.