### PR TITLE
Cover some corner cases

### DIFF
--- a/libs/processing/process_area.py
+++ b/libs/processing/process_area.py
@@ -310,7 +310,8 @@ def general_text_area(candidates, roi, is_number):
         words = []
         for group in aligned_groups:
             word = process_lines(group, roi, is_number)
-            words.append(word.strip())
+            if word:
+                words.append(word.strip())
         results['inferred'] = '\n'.join(words)
     else:
         results['inferred'] = construct_lines(list(candidate_lines.values())[0])

--- a/libs/processing/store_results.py
+++ b/libs/processing/store_results.py
@@ -100,14 +100,15 @@ def store_results(results, artefacts, output_file):
             extra_worksheet.write(f'A{row_number}', key)
             row_number += 1
             for extra in artefacts[key]:
-                extra_worksheet.write(f'A{row_number}', extra[0])
+                if extra[1].size != 0:
+                    extra_worksheet.write(f'A{row_number}', extra[0])
 
-                filename = store_image(extra[1], images_directory, row_number+1000)
-                height, width, _ = extra[1].shape
-                max_width = max(width, max_width)
-                extra_worksheet.insert_image(f'B{row_number}', filename)
-                extra_worksheet.set_row_pixels(row_number-1, height)
-                row_number += 1
+                    filename = store_image(extra[1], images_directory, row_number+1000)
+                    height, width, _ = extra[1].shape
+                    max_width = max(width, max_width)
+                    extra_worksheet.insert_image(f'B{row_number}', filename)
+                    extra_worksheet.set_row_pixels(row_number-1, height)
+                    row_number += 1
             row_number += 1
     
     extra_worksheet.set_column_pixels(1, 2, max_width)


### PR DESCRIPTION
- sometimes the only word in a box is a non-ascii character -> this is then transformed to `None`
- small cut image can be empty