### PR TITLE
Use compressed images

### DIFF
--- a/libs/extract_ROI/autodect.py
+++ b/libs/extract_ROI/autodect.py
@@ -99,7 +99,7 @@ def find_residuals(image, credentials):
 
     image_pil = Image.fromarray(image)
     image_stream = io.BytesIO()
-    image_pil.save(image_stream, format='PNG')
+    image_pil.save(image_stream, format='JPEG')
 
     identified = google.annotate_image(image_stream)
     identified = google.process_output(identified)

--- a/libs/pdf_to_image.py
+++ b/libs/pdf_to_image.py
@@ -44,5 +44,5 @@ def get_image_size(logsheet_image):
     """
     img_file = BytesIO()
     image = Image.fromarray(logsheet_image)
-    image.save(img_file, 'png', quality='keep')
+    image.save(img_file, format='JPEG')
     return img_file.tell()

--- a/libs/processing/read_content.py
+++ b/libs/processing/read_content.py
@@ -4,7 +4,7 @@ from libs.processing.process_area import general_text_area
 from libs.processing.checkbox import is_ticked
 
 
-def process_content(indetified_content, logsheet_image, config):
+def process_content(indetified_content, logsheet_image, config, checkbox_edges):
     """
     Top level function to read content of ROIs.
 
@@ -12,6 +12,7 @@ def process_content(indetified_content, logsheet_image, config):
         indetified_content (dict): identified content using OCR services
         logsheet_image (Image): logsheet image
         config (LogsheetConfig): configuration of given logsheet
+        checkbox_edges (bool): cutoff edges for checkboxes to avoid detecting box
 
     Returns:
         list: a list of identified content with its confidence
@@ -30,7 +31,7 @@ def process_content(indetified_content, logsheet_image, config):
         if region.content_type == 'Barcode':
             content['inferred'] = read_barcode(fragment, candidates)
         elif region.content_type == 'Checkbox':
-            content['inferred'] = is_ticked(fragment)
+            content['inferred'] = is_ticked(fragment, edge_ignore_percentage=checkbox_edges)
         else:
             is_number = region.content_type == 'Number'
             content = general_text_area(candidates, region, is_number)

--- a/libs/services/call_services.py
+++ b/libs/services/call_services.py
@@ -13,7 +13,7 @@ def call_services(logsheet_image, credentials, config):
 
     image_pil = Image.fromarray(logsheet_image)
     image_stream = io.BytesIO()
-    image_pil.save(image_stream, format='PNG')
+    image_pil.save(image_stream, format='JPEG')
 
     google_identified = google.annotate_image(image_stream)
     google_identified = google.process_output(google_identified)


### PR DESCRIPTION
Compressed images can be send to cloud OCR services. Close #69.

Also added parameter `--ugly_checkboxes` to `process_logsheet` to switch sensitivity of checkboxes detection.