### PR TITLE
Enable manual alignment

### DIFF
--- a/libs/processing/align_images.py
+++ b/libs/processing/align_images.py
@@ -48,13 +48,14 @@ def find_corners(image):
     return outer_corners
 
 
+def transform(scanned, template, scanned_points, template_points):
+    # Compute the transformation matrix and apply it
+    h, _ = cv2.findHomography(np.array(scanned_points), np.array(template_points))
+    return cv2.warpPerspective(scanned, h, (template.shape[1], template.shape[0]))
+
+
 def align_images(scanned, template):
     # Find corners in both images
     template_corners = find_corners(template)
     scanned_corners = find_corners(scanned)
-
-    # Compute the transformation matrix and apply it
-    h, _ = cv2.findHomography(np.array(scanned_corners), np.array(template_corners))
-    aligned = cv2.warpPerspective(scanned, h, (template.shape[1], template.shape[0]))
-
-    return aligned
+    return transform(scanned, template, scanned_corners, template_corners)

--- a/manual_align.py
+++ b/manual_align.py
@@ -1,8 +1,9 @@
 import cv2
 import numpy as np
+import argparse
 
-from libs.pdf_to_image import convert_pdf_to_image
-from libs.processing.align_images import compute_closest_point
+from libs.pdf_to_image import convert_pdf_to_image, resize_image
+from libs.processing.align_images import compute_closest_point, transform
 
 
 def select_points(image):
@@ -17,7 +18,7 @@ def select_points(image):
 
     while len(points) < 4:
         # TODO end only on q or Esc
-        cv2.imshow("Select Points", image)
+        cv2.imshow('Select Points', image)
         cv2.setMouseCallback('Select Points', click_event)
         key = cv2.waitKey(0)
 
@@ -34,47 +35,64 @@ def select_points(image):
     cv2.destroyAllWindows()
     return points
 
-def align_images(template, target, template_points, target_points):
-    template_points = np.float32(template_points)
-    target_points = np.float32(target_points)
+def store_output():
+    pass
 
-    matrix = cv2.getPerspectiveTransform(target_points, template_points)
-    result = cv2.warpPerspective(target, matrix, (template.shape[1], template.shape[0]))
 
-    return result
+def process(target, template):
+    height, width, _ = target.shape
 
-def main(template_path, target_path, output_path):
-    # Convert PDF images to OpenCV format
-    template = np.array(convert_pdf_to_image(template_path))
-    target = np.array(convert_pdf_to_image(target_path))
+    target = resize_image(target, (width, height))
+    template = resize_image(template, (width, height))
 
     # Display and select points on the template image
     template_points = select_points(template.copy())
-    print(template_points)
+    # template_points = [(29, 233), (2218, 236), (30, 3074), (2213, 3084)]
+
+    # sort by finding closest points to corners
+    template_points = [compute_closest_point((0, 0), template_points),
+                       compute_closest_point((width, 0), template_points),
+                       compute_closest_point((width, height), template_points),
+                       compute_closest_point((0, height), template_points)]
 
     # Display and select points on the target image
     target_points = select_points(target.copy())
-    print(target_points)
+    # target_points = [(149, 322), (2435, 338), (107, 3270), (2396, 3306)]
 
-    # TODO sort by finding closest points to corners
-    # compute_closest_point
+    target_points = [compute_closest_point((0, 0), target_points),
+                     compute_closest_point((width, 0), target_points),
+                     compute_closest_point((width, height), target_points),
+                     compute_closest_point((0, height), target_points)]
 
     # Align the images based on the selected points
-    aligned_image = align_images(template, target, template_points, target_points)
+    return transform(target, template, target_points, template_points)
+
+
+def main(template_path, target_path, output_path, backside_template):
+    # Convert PDF images to OpenCV format
+    # TODO dont touch other pages if present? (backside)
+    template = np.array(convert_pdf_to_image(template_path))
+    target = np.array(convert_pdf_to_image(target_path))
+
+    aligned_image = process(template, target)
 
     # TODO store as pdf
     # Save the aligned image to the output file
     cv2.imwrite(output_path, aligned_image)
 
-if __name__ == "__main__":
-    import sys
 
-    # TODO make proper interface
-    # dont touch other pages if present? (backside)
+if __name__ == '__main__':
+    args_parser = argparse.ArgumentParser(description='Manual alignment tool for PDF files')
 
-    if len(sys.argv) != 4:
-        print("Usage: python manual_alignment_tool.py template.pdf target.pdf output.jpg")
-        sys.exit(1)
+    args_parser._action_groups.pop()
+    required = args_parser.add_argument_group('required arguments')
+    optional = args_parser.add_argument_group('optional arguments')
 
-    template_path, target_path, output_path = sys.argv[1], sys.argv[2], sys.argv[3]
-    main(template_path, target_path, output_path)
+    required.add_argument('--pdf_template', type=str, required=True, help='Path to the template PDF file')
+    required.add_argument('--pdf_logsheet', type=str, required=True, help='Path to the target PDF file')
+    required.add_argument('--output', type=str, required=True, help='Path to the output aligned image file')
+
+    optional.add_argument('--backside_template', type=str, help='PDF template of the backside')
+
+    args = args_parser.parse_args()
+    main(args.pdf_template, args.pdf_logsheet, args.output, args.backside_template)

--- a/manual_align.py
+++ b/manual_align.py
@@ -11,30 +11,31 @@ from libs.processing.align_images import compute_closest_point, transform
 
 
 def select_points(image, window_name):
+    original_image = image.copy()
     points = []
 
     def click_event(event, x, y, flags, params):
-        # TODO dont allow to draw if len(points) > 3
         if event == cv2.EVENT_LBUTTONDOWN:
-            points.append((x,y))
-            cv2.circle(image, (x,y), 15, (0, 0, 255), -1)
-            cv2.imshow(window_name, image)
+            if len(points) < 4:
+                points.append((x,y))
+                cv2.circle(image, (x,y), 15, (0, 0, 255), -1)
+                cv2.imshow(window_name, image)
 
-    while len(points) < 4:
-        # TODO end only on q or Esc
+    keep_running = True
+    while keep_running:
         cv2.imshow(window_name, image)
         cv2.setMouseCallback(window_name, click_event)
         key = cv2.waitKey(0)
 
-        if key == ord('q'):
-            break
-        elif key == ord('r') and points:
+        if key == ord('r') and points:
             points.pop()  # undo the last point
-            # TODO remove also from the image
-        elif key == 27:  # Esc key to exit 
-            # TODO join with q
+            image = original_image.copy()
+            for (x,y) in points:
+                cv2.circle(image, (x,y), 15, (0, 0, 255), -1)
+            cv2.imshow(window_name, image)
+        elif key in [27, ord('q')]: # Esc or q key to exit 
             cv2.destroyAllWindows()
-            exit()
+            keep_running = False
 
     cv2.destroyAllWindows()
     return points

--- a/manual_align.py
+++ b/manual_align.py
@@ -1,0 +1,80 @@
+import cv2
+import numpy as np
+
+from libs.pdf_to_image import convert_pdf_to_image
+from libs.processing.align_images import compute_closest_point
+
+
+def select_points(image):
+    points = []
+
+    def click_event(event, x, y, flags, params):
+        # TODO dont allow to draw if len(points) > 3
+        if event == cv2.EVENT_LBUTTONDOWN:
+            points.append((x,y))
+            cv2.circle(image, (x,y), 15, (0, 0, 255), -1)
+            cv2.imshow('Select Points', image)
+
+    while len(points) < 4:
+        # TODO end only on q or Esc
+        cv2.imshow("Select Points", image)
+        cv2.setMouseCallback('Select Points', click_event)
+        key = cv2.waitKey(0)
+
+        if key == ord('q'):
+            break
+        elif key == ord('r') and points:
+            points.pop()  # undo the last point
+            # TODO remove also from the image
+        elif key == 27:  # Esc key to exit 
+            # TODO join with q
+            cv2.destroyAllWindows()
+            exit()
+
+    cv2.destroyAllWindows()
+    return points
+
+def align_images(template, target, template_points, target_points):
+    template_points = np.float32(template_points)
+    target_points = np.float32(target_points)
+
+    matrix = cv2.getPerspectiveTransform(target_points, template_points)
+    result = cv2.warpPerspective(target, matrix, (template.shape[1], template.shape[0]))
+
+    return result
+
+def main(template_path, target_path, output_path):
+    # Convert PDF images to OpenCV format
+    template = np.array(convert_pdf_to_image(template_path))
+    target = np.array(convert_pdf_to_image(target_path))
+
+    # Display and select points on the template image
+    template_points = select_points(template.copy())
+    print(template_points)
+
+    # Display and select points on the target image
+    target_points = select_points(target.copy())
+    print(target_points)
+
+    # TODO sort by finding closest points to corners
+    # compute_closest_point
+
+    # Align the images based on the selected points
+    aligned_image = align_images(template, target, template_points, target_points)
+
+    # TODO store as pdf
+    # Save the aligned image to the output file
+    cv2.imwrite(output_path, aligned_image)
+
+if __name__ == "__main__":
+    import sys
+
+    # TODO make proper interface
+    # dont touch other pages if present? (backside)
+
+    if len(sys.argv) != 4:
+        print("Usage: python manual_alignment_tool.py template.pdf target.pdf output.jpg")
+        sys.exit(1)
+
+    template_path, target_path, output_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    main(template_path, target_path, output_path)

--- a/process_logsheet.py
+++ b/process_logsheet.py
@@ -23,7 +23,7 @@ def load_credentials(google_credentials, amazon_credentials, azure_credentials):
     return {'google': google_credentials, 'amazon': amazon_credentials, 'azure': azure_credentials}
 
 
-def preprocess_input(scanned_logsheet, template, config, page, max_size=4, dpi=300):
+def preprocess_input(scanned_logsheet, template, config, page, skip_alignment, max_size=4, dpi=300):
     # convert pdfs to images
     template_image = convert_pdf_to_image(template, dpi=dpi)
     template_image = np.array(template_image)
@@ -36,14 +36,15 @@ def preprocess_input(scanned_logsheet, template, config, page, max_size=4, dpi=3
     template_image = resize_image(template_image, (config.width, config.height))
 
     # fix logsheet_image (reorient and scale)
-    logsheet_image = align_images(logsheet_image, template_image)
+    if not skip_alignment:
+        logsheet_image = align_images(logsheet_image, template_image)
 
     if get_image_size(logsheet_image) > max_size * 2**20:
-        logsheet_image = preprocess_input(scanned_logsheet, template, config, page, max_size, dpi=dpi-50)
+        logsheet_image = preprocess_input(scanned_logsheet, template, config, page, skip_alignment, max_size, dpi=dpi-50)
     return logsheet_image
 
 
-def process_logsheet(logsheet, template, config_file, credentials, debug=False, front=True, checkbox_edges=0.2):
+def process_logsheet(logsheet, template, config_file, credentials, debug=False, front=True, checkbox_edges=0.2, skip_alignment=False):
     # load CSV config
     config = LogsheetConfig([], [])
     config.import_from_json(config_file)
@@ -51,7 +52,7 @@ def process_logsheet(logsheet, template, config_file, credentials, debug=False, 
     page = 0 if front else 1
 
     # assume PDF and CSV config correspond to each other (QR codes are not reliable anyway)
-    logsheet_image = preprocess_input(logsheet, template, config, page)
+    logsheet_image = preprocess_input(logsheet, template, config, page, skip_alignment)
     # call external OCR services
     identified_content = call_services(logsheet_image, credentials, config)
 
@@ -63,7 +64,7 @@ def process_logsheet(logsheet, template, config_file, credentials, debug=False, 
 
 
 def main(scanned_logsheet, template, config_file, output_file, google_credentials, amazon_credentials, azure_credentials, 
-         debug, backside, backside_template, backside_config, ugly_checkboxes):
+         debug, backside, backside_template, backside_config, ugly_checkboxes, aligned):
     
     checkbox_edges = 0.2
     if ugly_checkboxes:
@@ -72,12 +73,12 @@ def main(scanned_logsheet, template, config_file, output_file, google_credential
     credentials = load_credentials(google_credentials, amazon_credentials, azure_credentials)
     
     # extract contents from the front page
-    contents, artefacts = process_logsheet(scanned_logsheet, template, config_file, credentials, debug=debug, checkbox_edges=checkbox_edges)
+    contents, artefacts = process_logsheet(scanned_logsheet, template, config_file, credentials, debug=debug, checkbox_edges=checkbox_edges, skip_alignment=aligned)
 
     # extract contents from the back side (if present)
     if backside:
         contents_back, artefacts_back = process_logsheet(scanned_logsheet, backside_template, backside_config, credentials,
-                                                         debug=debug, checkbox_edges=checkbox_edges, front=False)
+                                                         debug=debug, checkbox_edges=checkbox_edges, front=False, skip_alignment=aligned)
 
         # join results
         contents += contents_back
@@ -112,6 +113,7 @@ if __name__ == '__main__':
     optional.add_argument('--backside_template', type=str, help='PDF template of the backside')
     optional.add_argument('--backside_config', type=str, help='Path to JSON file containing config of the backside')
     optional.add_argument('--ugly_checkboxes', action=argparse.BooleanOptionalAction, default=False, help='Checkboxes in the logsheet have irregular shape or large edges.')
+    optional.add_argument('--aligned', action=argparse.BooleanOptionalAction, default=False, help='The scanned image is already aligned with template, skip automatic alignment step.')
 
     args = args_parser.parse_args()
 
@@ -119,4 +121,4 @@ if __name__ == '__main__':
         args_parser.error('The --backside argument requires --backside_template and --backside_config.')
 
     main(args.pdf_logsheet, args.pdf_template, args.config_file, args.output_file, args.google, args.amazon, args.azure, 
-         args.debug, args.backside, args.backside_template, args.backside_config, args.ugly_checkboxes)
+         args.debug, args.backside, args.backside_template, args.backside_config, args.ugly_checkboxes, args.aligned)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ azure-cognitiveservices-vision-computervision
 pyzbar
 biopython
 scikit-image
+img2pdf
+PyPDF2


### PR DESCRIPTION
This PR implements option to apply manual alignment of scan and template. The alignment step in `process_logsheet` can be then skipped entirely with `--aligned` CLI argument.

Close #71.
Close #72.